### PR TITLE
[VOICEVOX] Upgrade pyopenjtalk and lock versions in requirements

### DIFF
--- a/3rdparty/voicevox/CMakeLists.txt
+++ b/3rdparty/voicevox/CMakeLists.txt
@@ -13,7 +13,7 @@ set(INSTALL_DIR ${PROJECT_SOURCE_DIR})
 catkin_package()
 
 catkin_generate_virtualenv(
-  INPUT_REQUIREMENTS requirements.in
+  INPUT_REQUIREMENTS requirements_$ENV{ROS_DISTRO}.txt
   PYTHON_INTERPRETER python3
   USE_SYSTEM_PACKAGES FALSE
 )

--- a/3rdparty/voicevox/requirements.in
+++ b/3rdparty/voicevox/requirements.in
@@ -2,7 +2,7 @@ PyYAML
 aiofiles
 appdirs
 fastapi
-git+https://github.com/VOICEVOX/pyopenjtalk@a85521a0a0f298f08d9e9b24987b3c77eb4aaff5#egg=pyopenjtalk
+git+https://github.com/VOICEVOX/pyopenjtalk@b35fc89fe42948a28e33aed886ea145a51113f88#egg=pyopenjtalk
 numpy
 python-multipart
 pyworld

--- a/3rdparty/voicevox/requirements_melodic.txt
+++ b/3rdparty/voicevox/requirements_melodic.txt
@@ -1,0 +1,32 @@
+cython==0.29.32           # via pyopenjtalk, pyworld
+aiofiles==0.8.0           # via -r requirements.in
+anyio==3.6.1              # via starlette
+appdirs==1.4.4            # via -r requirements.in
+asgiref==3.4.1            # via uvicorn
+cffi==1.15.1              # via soundfile
+click==8.0.4              # via uvicorn
+contextlib2==21.6.0       # via starlette
+contextvars==2.4          # via anyio, sniffio
+dataclasses==0.8          # via anyio, h11, pydantic
+fastapi==0.83.0           # via -r requirements.in
+h11==0.13.0               # via uvicorn
+idna==3.4                 # via anyio
+immutables==0.19          # via contextvars
+importlib-metadata==4.8.3  # via click
+importlib-resources==5.4.0  # via tqdm
+numpy==1.19.5             # via -r requirements.in, pyopenjtalk, pyworld, scipy
+pycparser==2.21           # via cffi
+pydantic==1.9.2           # via fastapi
+git+https://github.com/VOICEVOX/pyopenjtalk@b35fc89fe42948a28e33aed886ea145a51113f88#egg=pyopenjtalk  # via -r requirements.in
+python-multipart==0.0.5   # via -r requirements.in
+pyworld==0.3.0            # via -r requirements.in
+pyyaml==6.0               # via -r requirements.in
+scipy==1.5.4              # via -r requirements.in
+six==1.16.0               # via pyopenjtalk, python-multipart
+sniffio==1.2.0            # via anyio
+soundfile==0.11.0         # via -r requirements.in
+starlette==0.19.1         # via fastapi
+tqdm==4.64.1              # via pyopenjtalk
+typing-extensions==4.1.1  # via anyio, asgiref, h11, importlib-metadata, pydantic, starlette, uvicorn
+uvicorn==0.16.0           # via -r requirements.in
+zipp==3.6.0               # via importlib-metadata, importlib-resources

--- a/3rdparty/voicevox/requirements_melodic.txt
+++ b/3rdparty/voicevox/requirements_melodic.txt
@@ -17,7 +17,7 @@ importlib-resources==5.4.0  # via tqdm
 numpy==1.19.5             # via -r requirements.in, pyopenjtalk, pyworld, scipy
 pycparser==2.21           # via cffi
 pydantic==1.9.2           # via fastapi
-git+https://github.com/VOICEVOX/pyopenjtalk@b35fc89fe42948a28e33aed886ea145a51113f88#egg=pyopenjtalk  # via -r requirements.in
+git+https://github.com/mqcmd196/pyopenjtalk@4f6e725bb03af721413d9966d361e6384b6fde47#egg=pyopenjtalk
 python-multipart==0.0.5   # via -r requirements.in
 pyworld==0.3.0            # via -r requirements.in
 pyyaml==6.0               # via -r requirements.in

--- a/3rdparty/voicevox/requirements_noetic.txt
+++ b/3rdparty/voicevox/requirements_noetic.txt
@@ -1,0 +1,27 @@
+aiofiles==23.2.1          # via -r requirements.in
+annotated-types==0.6.0    # via pydantic
+anyio==4.3.0              # via starlette
+appdirs==1.4.4            # via -r requirements.in
+cffi==1.16.0              # via soundfile
+click==8.1.7              # via uvicorn
+cython==3.0.10            # via pyopenjtalk, pyworld
+exceptiongroup==1.2.0     # via anyio
+fastapi==0.110.1          # via -r requirements.in
+h11==0.14.0               # via uvicorn
+idna==3.6                 # via anyio
+numpy==1.24.4             # via -r requirements.in, pyopenjtalk, pyworld, scipy
+pycparser==2.22           # via cffi
+pydantic-core==2.16.3     # via pydantic
+pydantic==2.6.4           # via fastapi
+git+https://github.com/VOICEVOX/pyopenjtalk@b35fc89fe42948a28e33aed886ea145a51113f88#egg=pyopenjtalk  # via -r requirements.in
+python-multipart==0.0.9   # via -r requirements.in
+pyworld==0.3.4            # via -r requirements.in
+pyyaml==6.0.1             # via -r requirements.in
+scipy==1.10.1             # via -r requirements.in
+six==1.16.0               # via pyopenjtalk
+sniffio==1.3.1            # via anyio
+soundfile==0.12.1         # via -r requirements.in
+starlette==0.37.2         # via fastapi
+tqdm==4.66.2              # via pyopenjtalk
+typing-extensions==4.11.0  # via annotated-types, anyio, fastapi, pydantic, pydantic-core, starlette, uvicorn
+uvicorn==0.29.0           # via -r requirements.in


### PR DESCRIPTION
Pyopenjtalk maintainer had already noticed the build error introduced in https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/337#issuecomment-2041879363 .  See https://github.com/r9y9/pyopenjtalk/issues/65